### PR TITLE
fix: have generateURL return null for undefined filenames

### DIFF
--- a/src/adapters/azure/generateURL.ts
+++ b/src/adapters/azure/generateURL.ts
@@ -9,5 +9,8 @@ interface Args {
 export const getGenerateURL =
   ({ containerName, baseURL }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
-    return `${baseURL}/${containerName}/${path.posix.join(prefix, filename)}`
+    if (filename) {
+      return `${baseURL}/${containerName}/${path.posix.join(prefix, filename)}`
+    }
+    return null
   }

--- a/src/adapters/gcs/generateURL.ts
+++ b/src/adapters/gcs/generateURL.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { Storage } from '@google-cloud/storage'
+import type { Storage } from '@google-cloud/storage'
 import type { GenerateURL } from '../../types'
 
 interface Args {
@@ -10,7 +10,10 @@ interface Args {
 export const getGenerateURL =
   ({ gcs, bucket }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
-    return decodeURIComponent(
-      gcs.bucket(bucket).file(path.posix.join(prefix, filename)).publicUrl(),
-    )
+    if (filename) {
+      return decodeURIComponent(
+        gcs.bucket(bucket).file(path.posix.join(prefix, filename)).publicUrl(),
+      )
+    }
+    return null
   }

--- a/src/adapters/s3/generateURL.ts
+++ b/src/adapters/s3/generateURL.ts
@@ -10,5 +10,8 @@ interface Args {
 export const getGenerateURL =
   ({ config: { endpoint }, bucket }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
-    return `${endpoint}/${bucket}/${path.posix.join(prefix, filename)}`
+    if (filename) {
+      return `${endpoint}/${bucket}/${path.posix.join(prefix, filename)}`
+    }
+    return null
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type GenerateURL = (args: {
   filename: string
   collection: CollectionConfig
   prefix?: string
-}) => string | Promise<string>
+}) => string | null | Promise<string | null>
 
 export type StaticHandler = (
   req: PayloadRequest,


### PR DESCRIPTION
This lets the afterRead hook skip URLs for non-existent image sizes, cleaning up the following error:
```

[00:47:11] ERROR (payload): TypeError: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:387:5)
    at validateString (node:internal/validators:116:11)
    at Object.join (node:path:1172:7)
    at Object.generateURL (/project/node_modules/@payloadcms/plugin-cloud-storage/src/adapters/s3/generateURL.ts:13:48)
    at /project/node_modules/@payloadcms/plugin-cloud-storage/src/hooks/afterRead.ts:17:31
    at step (/project/node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterRead.js:33:23)
    at Object.next (/project/node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterRead.js:14:53)
    at /project/node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterRead.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/project/node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterRead.js:4:12)
```

I believe this was intended, based on `||` being used on the return value of generateURL here: https://github.com/payloadcms/plugin-cloud-storage/blob/2cd83f2aa6ceea00381dbf5ca16e1c83deb9f4f0/src/hooks/afterRead.ts#L23

