### PR TITLE
fix: content length header

### DIFF
--- a/src/adapters/azure/staticHandler.ts
+++ b/src/adapters/azure/staticHandler.ts
@@ -20,7 +20,7 @@ export const getHandler = ({ containerClient, collection }: Args): StaticHandler
       const blob = await blockBlobClient.download(0)
 
       res.set({
-        'Content-Length': blob.contentLanguage,
+        'Content-Length': blob.contentLength,
         'Content-Type': blob.contentType,
         ETag: blob.etag,
       })


### PR DESCRIPTION
Add correct Content-Length to response headers.

Fixes an issue when running Payload behind Traefik reverse proxy.

Traefik reverse proxy returns HTTP 500 when Content-Length HTTP header is malformed.