### PR TITLE
Lazily initialize storage clients

### DIFF
--- a/src/adapters/azure/handleDelete.ts
+++ b/src/adapters/azure/handleDelete.ts
@@ -5,12 +5,12 @@ import type { HandleDelete } from '../../types'
 
 interface Args {
   collection: CollectionConfig
-  containerClient: ContainerClient
+  getStorageClient: () => ContainerClient
 }
 
-export const getHandleDelete = ({ containerClient }: Args): HandleDelete => {
+export const getHandleDelete = ({ getStorageClient }: Args): HandleDelete => {
   return async ({ filename, doc: { prefix = '' } }) => {
-    const blockBlobClient = containerClient.getBlockBlobClient(path.posix.join(prefix, filename))
+    const blockBlobClient = getStorageClient().getBlockBlobClient(path.posix.join(prefix, filename))
     await blockBlobClient.deleteIfExists()
   }
 }

--- a/src/adapters/azure/handleUpload.ts
+++ b/src/adapters/azure/handleUpload.ts
@@ -5,22 +5,13 @@ import type { HandleUpload } from '../../types'
 
 interface Args {
   collection: CollectionConfig
-  containerClient: ContainerClient
-  allowContainerCreate: boolean
+  getStorageClient: () => ContainerClient
   prefix?: string
 }
 
-export const getHandleUpload = ({
-  allowContainerCreate,
-  containerClient,
-  prefix = '',
-}: Args): HandleUpload => {
-  if (allowContainerCreate) {
-    containerClient.createIfNotExists({ access: 'blob' })
-  }
-
+export const getHandleUpload = ({ getStorageClient, prefix = '' }: Args): HandleUpload => {
   return async ({ data, file }) => {
-    const blockBlobClient = containerClient.getBlockBlobClient(
+    const blockBlobClient = getStorageClient().getBlockBlobClient(
       path.posix.join(prefix, file.filename),
     )
 

--- a/src/adapters/azure/staticHandler.ts
+++ b/src/adapters/azure/staticHandler.ts
@@ -5,15 +5,15 @@ import type { StaticHandler } from '../../types'
 import { getFilePrefix } from '../../utilities/getFilePrefix'
 
 interface Args {
-  containerClient: ContainerClient
+  getStorageClient: () => ContainerClient
   collection: CollectionConfig
 }
 
-export const getHandler = ({ containerClient, collection }: Args): StaticHandler => {
+export const getHandler = ({ getStorageClient, collection }: Args): StaticHandler => {
   return async (req, res, next) => {
     try {
       const prefix = await getFilePrefix({ req, collection })
-      const blockBlobClient = containerClient.getBlockBlobClient(
+      const blockBlobClient = getStorageClient().getBlockBlobClient(
         path.posix.join(prefix, req.params.filename),
       )
 

--- a/src/adapters/gcs/generateURL.ts
+++ b/src/adapters/gcs/generateURL.ts
@@ -3,14 +3,14 @@ import { Storage } from '@google-cloud/storage'
 import type { GenerateURL } from '../../types'
 
 interface Args {
-  gcs: Storage
+  getStorageClient: () => Storage
   bucket: string
 }
 
 export const getGenerateURL =
-  ({ gcs, bucket }: Args): GenerateURL =>
+  ({ getStorageClient, bucket }: Args): GenerateURL =>
   ({ filename, prefix = '' }) => {
     return decodeURIComponent(
-      gcs.bucket(bucket).file(path.posix.join(prefix, filename)).publicUrl(),
+      getStorageClient().bucket(bucket).file(path.posix.join(prefix, filename)).publicUrl(),
     )
   }

--- a/src/adapters/gcs/handleDelete.ts
+++ b/src/adapters/gcs/handleDelete.ts
@@ -3,13 +3,13 @@ import { Storage } from '@google-cloud/storage'
 import type { HandleDelete } from '../../types'
 
 interface Args {
-  gcs: Storage
+  getStorageClient: () => Storage
   bucket: string
 }
 
-export const getHandleDelete = ({ gcs, bucket }: Args): HandleDelete => {
+export const getHandleDelete = ({ getStorageClient, bucket }: Args): HandleDelete => {
   return async ({ filename, doc: { prefix = '' } }) => {
-    await gcs.bucket(bucket).file(path.posix.join(prefix, filename)).delete({
+    await getStorageClient().bucket(bucket).file(path.posix.join(prefix, filename)).delete({
       ignoreNotFound: true,
     })
   }

--- a/src/adapters/gcs/handleUpload.ts
+++ b/src/adapters/gcs/handleUpload.ts
@@ -8,12 +8,17 @@ interface Args {
   bucket: string
   acl?: 'Private' | 'Public'
   prefix?: string
-  gcs: Storage
+  getStorageClient: () => Storage
 }
 
-export const getHandleUpload = ({ gcs, bucket, acl, prefix = '' }: Args): HandleUpload => {
+export const getHandleUpload = ({
+  getStorageClient,
+  bucket,
+  acl,
+  prefix = '',
+}: Args): HandleUpload => {
   return async ({ data, file }) => {
-    const gcsFile = gcs.bucket(bucket).file(path.posix.join(prefix, file.filename))
+    const gcsFile = getStorageClient().bucket(bucket).file(path.posix.join(prefix, file.filename))
     await gcsFile.save(file.buffer, {
       metadata: {
         contentType: file.mimeType,

--- a/src/adapters/gcs/index.ts
+++ b/src/adapters/gcs/index.ts
@@ -15,19 +15,23 @@ export interface Args {
 export const gcsAdapter =
   ({ options, bucket, acl }: Args): Adapter =>
   ({ collection, prefix }): GeneratedAdapter => {
-    const gcs = new Storage(options)
+    let storageClient: Storage | null = null
+    const getStorageClient = () => {
+      if (storageClient) return storageClient
+      return (storageClient = new Storage(options))
+    }
 
     return {
       handleUpload: getHandleUpload({
         collection,
-        gcs,
+        getStorageClient,
         bucket,
         acl,
         prefix,
       }),
-      handleDelete: getHandleDelete({ gcs, bucket }),
-      generateURL: getGenerateURL({ gcs, bucket }),
-      staticHandler: getHandler({ gcs, bucket, collection }),
+      handleDelete: getHandleDelete({ getStorageClient, bucket }),
+      generateURL: getGenerateURL({ getStorageClient, bucket }),
+      staticHandler: getHandler({ getStorageClient, bucket, collection }),
       webpack: extendWebpackConfig,
     }
   }

--- a/src/adapters/gcs/staticHandler.ts
+++ b/src/adapters/gcs/staticHandler.ts
@@ -5,16 +5,18 @@ import type { StaticHandler } from '../../types'
 import { getFilePrefix } from '../../utilities/getFilePrefix'
 
 interface Args {
-  gcs: Storage
+  getStorageClient: () => Storage
   bucket: string
   collection: CollectionConfig
 }
 
-export const getHandler = ({ gcs, bucket, collection }: Args): StaticHandler => {
+export const getHandler = ({ getStorageClient, bucket, collection }: Args): StaticHandler => {
   return async (req, res, next) => {
     try {
       const prefix = await getFilePrefix({ req, collection })
-      const file = gcs.bucket(bucket).file(path.posix.join(prefix, req.params.filename))
+      const file = getStorageClient()
+        .bucket(bucket)
+        .file(path.posix.join(prefix, req.params.filename))
 
       const [metadata] = await file.getMetadata()
 

--- a/src/adapters/s3/handleDelete.ts
+++ b/src/adapters/s3/handleDelete.ts
@@ -3,13 +3,13 @@ import type * as AWS from '@aws-sdk/client-s3'
 import type { HandleDelete } from '../../types'
 
 interface Args {
-  s3: AWS.S3
+  getStorageClient: () => AWS.S3
   bucket: string
 }
 
-export const getHandleDelete = ({ s3, bucket }: Args): HandleDelete => {
+export const getHandleDelete = ({ getStorageClient, bucket }: Args): HandleDelete => {
   return async ({ filename, doc: { prefix = '' } }) => {
-    await s3.deleteObject({
+    await getStorageClient().deleteObject({
       Bucket: bucket,
       Key: path.posix.join(prefix, filename),
     })

--- a/src/adapters/s3/handleUpload.ts
+++ b/src/adapters/s3/handleUpload.ts
@@ -8,12 +8,17 @@ interface Args {
   bucket: string
   acl?: 'private' | 'public-read'
   prefix?: string
-  s3: AWS.S3
+  getStorageClient: () => AWS.S3
 }
 
-export const getHandleUpload = ({ s3, bucket, acl, prefix = '' }: Args): HandleUpload => {
+export const getHandleUpload = ({
+  getStorageClient,
+  bucket,
+  acl,
+  prefix = '',
+}: Args): HandleUpload => {
   return async ({ data, file }) => {
-    await s3.putObject({
+    await getStorageClient().putObject({
       Bucket: bucket,
       Key: path.posix.join(prefix, file.filename),
       Body: file.buffer,

--- a/src/adapters/s3/index.ts
+++ b/src/adapters/s3/index.ts
@@ -15,19 +15,23 @@ export interface Args {
 export const s3Adapter =
   ({ config, bucket, acl }: Args): Adapter =>
   ({ collection, prefix }): GeneratedAdapter => {
-    const s3 = new AWS.S3(config)
+    let storageClient: AWS.S3 | null = null
+    const getStorageClient = () => {
+      if (storageClient) return storageClient
+      return (storageClient = new AWS.S3(config))
+    }
 
     return {
       handleUpload: getHandleUpload({
         collection,
-        s3,
+        getStorageClient,
         bucket,
         acl,
         prefix,
       }),
-      handleDelete: getHandleDelete({ s3, bucket }),
+      handleDelete: getHandleDelete({ getStorageClient, bucket }),
       generateURL: getGenerateURL({ bucket, config }),
-      staticHandler: getHandler({ bucket, s3, collection }),
+      staticHandler: getHandler({ bucket, getStorageClient, collection }),
       webpack: extendWebpackConfig,
     }
   }

--- a/src/adapters/s3/staticHandler.ts
+++ b/src/adapters/s3/staticHandler.ts
@@ -6,17 +6,17 @@ import type { StaticHandler } from '../../types'
 import { getFilePrefix } from '../../utilities/getFilePrefix'
 
 interface Args {
-  s3: AWS.S3
+  getStorageClient: () => AWS.S3
   bucket: string
   collection: CollectionConfig
 }
 
-export const getHandler = ({ s3, bucket, collection }: Args): StaticHandler => {
+export const getHandler = ({ getStorageClient, bucket, collection }: Args): StaticHandler => {
   return async (req, res, next) => {
     try {
       const prefix = await getFilePrefix({ req, collection })
 
-      const object = await s3.getObject({
+      const object = await getStorageClient().getObject({
         Bucket: bucket,
         Key: path.posix.join(prefix, req.params.filename),
       })

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -86,9 +86,9 @@ export const cloudStorage =
 
         return existingCollection
       }),
-      onInit: payload => {
+      onInit: async payload => {
         initFunctions.forEach(fn => fn())
-        if (config.onInit) config.onInit(payload)
+        if (config.onInit) await config.onInit(payload)
       },
     }
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,6 +21,8 @@ export const cloudStorage =
 
     const webpack = extendWebpackConfig({ options: pluginOptions, config })
 
+    const initFunctions: (() => void)[] = []
+
     return {
       ...config,
       admin: {
@@ -35,6 +37,8 @@ export const cloudStorage =
             collection: existingCollection,
             prefix: options.prefix,
           })
+
+          if (adapter.onInit) initFunctions.push(adapter.onInit)
 
           const fields = getFields({
             collection: existingCollection,
@@ -82,5 +86,9 @@ export const cloudStorage =
 
         return existingCollection
       }),
+      onInit: payload => {
+        initFunctions.forEach(fn => fn())
+        if (config.onInit) config.onInit(payload)
+      },
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface GeneratedAdapter {
   generateURL: GenerateURL
   staticHandler: StaticHandler
   webpack?: (config: WebpackConfig) => WebpackConfig
+  onInit?: () => void
 }
 
 export type Adapter = (args: { collection: CollectionConfig; prefix?: string }) => GeneratedAdapter


### PR DESCRIPTION
Lazily initialize AWS S3, Google Cloud Storage & Azure Blob Storage clients in corresponding adapters.

This has the benefit of not creating any clients/doing any requests in build time, but only in runtime, allowing one to follow the "build once, deploy anywhere" principle.

E.g. your connection string could be injected as an environment variable at runtime, so the same image could be deployed to both staging and production environments.

By removing any requests done at build time, the plugin also works for virtual private networks where there is no public IP.

I have tested the Azure adapter, but not the Google Cloud Storage or S3 ones. Maybe someone can help me out here?

Solves #7 