### PR TITLE
feat: ensure "accept-ranges" header is passed trough on static files for S3 and Azure adapters

### DIFF
--- a/src/adapters/azure/staticHandler.ts
+++ b/src/adapters/azure/staticHandler.ts
@@ -20,6 +20,7 @@ export const getHandler = ({ getStorageClient, collection }: Args): StaticHandle
       const blob = await blockBlobClient.download(0)
 
       res.set({
+        'Accept-Ranges': blob.acceptRanges,
         'Content-Length': blob.contentLength,
         'Content-Type': blob.contentType,
         ETag: blob.etag,

--- a/src/adapters/s3/staticHandler.ts
+++ b/src/adapters/s3/staticHandler.ts
@@ -22,6 +22,7 @@ export const getHandler = ({ getStorageClient, bucket, collection }: Args): Stat
       })
 
       res.set({
+        'Accept-Ranges': object.AcceptRanges,
         'Content-Length': object.ContentLength,
         'Content-Type': object.ContentType,
         ETag: object.ETag,


### PR DESCRIPTION
Added "accept-ranges" header to the list of header passed trough on S3 and Azure adapter.

I checked the GCS metadata object, and it seems that the accept-ranges header is not returned, at least when using the local emulator, so I'm not sure if we should handle it somehow or just skip it.