### PR TITLE
Added documentation for AWS EC2 IAM Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ const adapter = s3Adapter({
 
 // Now you can pass this adapter to the plugin
 ```
+Note that the credentials option does not have to be used when you are using PayloadCMS on an EC2 instance that has been configured with an IAM Role with necessary permissions.
 
 #### Other S3-Compatible Storage
 


### PR DESCRIPTION
Specified that you don't need to provide any credentials when using a correct IAM Role. IAM Roles are recommended by AWS over direct credentials due to superior security.