### PR TITLE
Add imagekit support

### DIFF
--- a/src/adapters/imagekit/generateURL.ts
+++ b/src/adapters/imagekit/generateURL.ts
@@ -1,0 +1,19 @@
+import ImageKit from "imagekit";
+import path from "path";
+import type { GenerateURL } from "../../types";
+
+interface Args {
+  getImageKit: () => ImageKit;
+  urlEndpoint: string;
+}
+
+export const getGenerateURL =
+  ({ getImageKit, urlEndpoint }: Args): GenerateURL =>
+  async ({ filename, prefix = "", cloudImageID }) => {
+
+    const fileDetailsResponse = await getImageKit().getFileDetails(cloudImageID);
+
+    return decodeURIComponent(
+      fileDetailsResponse.url
+    );
+  };

--- a/src/adapters/imagekit/handleDelete.ts
+++ b/src/adapters/imagekit/handleDelete.ts
@@ -1,0 +1,12 @@
+import type { HandleDelete } from '../../types'
+import ImageKit from 'imagekit'
+
+interface Args {
+  getImageKit: () => ImageKit
+}
+
+export const getHandleDelete = ({ getImageKit }: Args): HandleDelete => {
+  return async ({ filename, doc }) => {
+    const response = await getImageKit().deleteFile(doc?.cloudImageID);
+  }
+}

--- a/src/adapters/imagekit/handleUpload.ts
+++ b/src/adapters/imagekit/handleUpload.ts
@@ -1,0 +1,37 @@
+import ImageKit from 'imagekit'
+import path from 'path'
+import type { CollectionConfig } from 'payload/types'
+import type { HandleUpload } from '../../types'
+
+interface Args {
+  collection: CollectionConfig
+  prefix?: string
+  getImageKit: () => ImageKit
+}
+
+export const getHandleUpload = ({
+  getImageKit,
+  prefix = '',
+}: Args): HandleUpload => {
+  return async ({ data, file }) => {
+
+
+    const response = await getImageKit().upload({
+      file : file.buffer, //required
+      fileName : file.filename,   //required
+      /*extensions: [
+          {
+              name: "google-auto-tagging",
+              maxTags: 5,
+              minConfidence: 95,
+          }
+      ],*/
+    });
+
+    console.log("Upload response", response)
+
+    data.cloudImageID = response?.fileId;
+    data.filename = response?.name;
+    return data;
+  }
+}

--- a/src/adapters/imagekit/index.ts
+++ b/src/adapters/imagekit/index.ts
@@ -1,0 +1,42 @@
+import type { Adapter, GeneratedAdapter } from "../../types";
+import { getGenerateURL } from "./generateURL";
+import { getHandler } from "./staticHandler";
+import { getHandleDelete } from "./handleDelete";
+import { getHandleUpload } from "./handleUpload";
+import { extendWebpackConfig } from "./webpack";
+import ImageKit from "imagekit";
+
+export interface Args {
+  publicKey: string;
+  privateKey: string;
+  urlEndpoint: string;
+}
+
+export const imageKitAdapter =
+  ({ publicKey, privateKey, urlEndpoint }: Args): Adapter =>
+  ({ collection, prefix }): GeneratedAdapter => {
+
+    let imageKit: ImageKit | null = null;
+
+    const getImageKit = () => {
+      if (imageKit) return imageKit;
+      return (imageKit = new ImageKit({
+        publicKey: publicKey,
+        privateKey: privateKey,
+        urlEndpoint: urlEndpoint,
+      }));
+    };
+
+
+    return {
+      handleUpload: getHandleUpload({
+        collection,
+        prefix,
+        getImageKit,
+      }),
+      handleDelete: getHandleDelete({ getImageKit }),
+      generateURL: getGenerateURL({ getImageKit, urlEndpoint }),
+      staticHandler: getHandler({ getImageKit, urlEndpoint, collection }),
+      webpack: extendWebpackConfig,
+    };
+  };

--- a/src/adapters/imagekit/mock.js
+++ b/src/adapters/imagekit/mock.js
@@ -1,0 +1,3 @@
+exports.Storage = function () {
+  return null
+}

--- a/src/adapters/imagekit/staticHandler.ts
+++ b/src/adapters/imagekit/staticHandler.ts
@@ -1,0 +1,44 @@
+import path from 'path'
+import type { CollectionConfig } from 'payload/types'
+import type { StaticHandler } from '../../types'
+import { getFilePrefix } from '../../utilities/getFilePrefix'
+import ImageKit from "imagekit";
+
+interface Args {
+  getImageKit: () => ImageKit,
+  urlEndpoint: string,
+  collection: CollectionConfig
+}
+
+export const getHandler = ({ getImageKit, urlEndpoint, collection }: Args): StaticHandler => {
+  return async (req, res, next) => {
+    console.log("StaticHandler", res);
+
+    //TODO
+    /*
+    try {
+      const prefix = await getFilePrefix({ req, collection })
+
+      const url = getImageKit().url({
+        path: path.posix.join(prefix, req.params.filename),
+        urlEndpoint: urlEndpoint,
+        /*transformation : [{
+            "height" : "300",
+            "width" : "400"
+        }]*//*
+      });
+
+      const [metadata] = await file.getMetadata()
+
+      res.set({
+        'Content-Length': metadata.size,
+        'Content-Type': metadata.contentType,
+        ETag: metadata.etag,
+      })
+
+      return file.createReadStream().pipe(res)
+    } catch (err: unknown) {
+      return next()
+    }*/
+  }
+}

--- a/src/adapters/imagekit/webpack.ts
+++ b/src/adapters/imagekit/webpack.ts
@@ -1,0 +1,17 @@
+import type { Configuration as WebpackConfig } from 'webpack'
+import path from 'path'
+
+export const extendWebpackConfig = (existingWebpackConfig: WebpackConfig): WebpackConfig => {
+  const newConfig: WebpackConfig = {
+    ...existingWebpackConfig,
+    resolve: {
+      ...(existingWebpackConfig.resolve || {}),
+      alias: {
+        ...(existingWebpackConfig.resolve?.alias ? existingWebpackConfig.resolve.alias : {}),
+        'imagekit': path.resolve(__dirname, './mock.js'),
+      },
+    },
+  }
+
+  return newConfig
+}

--- a/src/fields/getFields.ts
+++ b/src/fields/getFields.ts
@@ -38,7 +38,21 @@ export const getFields = ({
     },
   }
 
+  // Optional, if needed for the adapter
+  const cloudImageIDField: Field = {
+    name: 'cloudImageID',
+    type: 'text',
+    admin: {
+      readOnly: true,
+      disabled: true,
+    },
+  }
+
   const fields = [...collection.fields]
+
+  fields.push({
+    ...cloudImageIDField,
+  })
 
   // Inject a hook into all URL fields to generate URLs
 
@@ -150,6 +164,8 @@ export const getFields = ({
       defaultValue: path.posix.join(prefix),
     })
   }
+
+  
 
   return fields
 }

--- a/src/hooks/afterRead.ts
+++ b/src/hooks/afterRead.ts
@@ -22,6 +22,7 @@ export const getAfterReadHook =
         collection,
         filename,
         prefix,
+        cloudImageID: data?.cloudImageID,
       })
     }
 
@@ -31,6 +32,7 @@ export const getAfterReadHook =
         filename,
         prefix,
         size,
+        cloudImageID: data?.cloudImageID,
       })
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,14 @@ export interface TypeWithPrefix {
   prefix?: string
 }
 
+export interface TypeWithOptionalData {
+  cloudImageID?: string
+}
+
 export type HandleDelete = (args: {
   collection: CollectionConfig
   req: PayloadRequest
-  doc: TypeWithID & FileData & TypeWithPrefix
+  doc: TypeWithID & FileData & TypeWithPrefix & TypeWithOptionalData
   filename: string
 }) => Promise<void> | void
 
@@ -32,6 +36,7 @@ export type GenerateURL = (args: {
   filename: string
   collection: CollectionConfig
   prefix?: string
+  cloudImageID?: string
 }) => string | Promise<string>
 
 export type StaticHandler = (
@@ -55,7 +60,8 @@ export type GenerateFileURL = (args: {
   collection: CollectionConfig
   filename: string
   prefix?: string
-  size?: ImageSize
+  size?: ImageSize,
+  cloudImageID?: string
 }) => Promise<string> | string
 
 export interface CollectionOptions {


### PR DESCRIPTION
This currently only works with `disablePayloadAccessControl` set to `true`. Imagekit works a lot with the file id and not just the file name. However, this plugin seems to be primarily designed with file names in mind.

While getting a way with that by creating an additional cloudImageID field and storing the image ID in it, this does not work for the StaticHandler as I only have the file name there.

Please check it out and let me know how to best handle that / how to improve on the current work!