### PR TITLE
feat(s3): implement multipart upload

### DIFF
--- a/dev/src/mocks/fileStub.js
+++ b/dev/src/mocks/fileStub.js
@@ -1,0 +1,1 @@
+export default 'file-stub'

--- a/dev/src/mocks/promisifyMock.js
+++ b/dev/src/mocks/promisifyMock.js
@@ -1,0 +1,1 @@
+export const promisify = () => {}

--- a/src/adapters/s3/handleUpload.ts
+++ b/src/adapters/s3/handleUpload.ts
@@ -18,13 +18,76 @@ export const getHandleUpload = ({
   prefix = '',
 }: Args): HandleUpload => {
   return async ({ data, file }) => {
-    await getStorageClient().putObject({
+    const fileKey = path.posix.join(prefix, file.filename)
+    console.log('Uploading file...', { fileKey })
+
+    if (file.buffer.length < 1024 * 1024 * 100) {
+      await getStorageClient().putObject({
+        Bucket: bucket,
+        Key: fileKey,
+        Body: file.buffer,
+        ACL: acl,
+        ContentType: file.mimeType,
+      })
+
+      return data
+    }
+
+    console.log('Initiating multipart upload...', { fileKey })
+    const { UploadId: uploadId } = await getStorageClient().createMultipartUpload({
       Bucket: bucket,
-      Key: path.posix.join(prefix, file.filename),
-      Body: file.buffer,
+      Key: fileKey,
       ACL: acl,
       ContentType: file.mimeType,
     })
+
+    if (!uploadId) {
+      throw new Error('No upload ID returned from S3')
+    }
+
+    const partSize = 1024 * 1024 * 5 // 5MB
+    const parts = []
+
+    try {
+      const totalParts = file.buffer.length / partSize
+      for (let i = 0; i < file.buffer.length; i += partSize) {
+        const partNumber = i / partSize + 1
+        const part = Uint8Array.prototype.slice.call(file.buffer, i, i + partSize)
+
+        console.log('Uploading part...', {
+          fileKey,
+          partNumber,
+          totalParts,
+        })
+
+        const uploadPart = await getStorageClient().uploadPart({
+          Bucket: bucket,
+          Key: fileKey,
+          Body: part,
+          PartNumber: partNumber,
+          UploadId: uploadId,
+        })
+        parts.push({
+          ETag: uploadPart.ETag,
+          PartNumber: partNumber,
+        })
+      }
+
+      await getStorageClient().completeMultipartUpload({
+        Bucket: bucket,
+        Key: fileKey,
+        MultipartUpload: {
+          Parts: parts,
+        },
+        UploadId: uploadId,
+      })
+    } catch {
+      await getStorageClient().abortMultipartUpload({
+        Bucket: bucket,
+        Key: fileKey,
+        UploadId: uploadId,
+      })
+    }
 
     return data
   }

--- a/src/adapters/s3/handleUpload.ts
+++ b/src/adapters/s3/handleUpload.ts
@@ -1,6 +1,8 @@
+import fs from 'fs'
 import path from 'path'
 import type * as AWS from '@aws-sdk/client-s3'
 import type { CollectionConfig } from 'payload/types'
+import type stream from 'stream'
 import type { HandleUpload } from '../../types'
 
 interface Args {
@@ -19,75 +21,21 @@ export const getHandleUpload = ({
 }: Args): HandleUpload => {
   return async ({ data, file }) => {
     const fileKey = path.posix.join(prefix, file.filename)
-    console.log('Uploading file...', { fileKey })
 
-    if (file.buffer.length < 1024 * 1024 * 100) {
-      await getStorageClient().putObject({
-        Bucket: bucket,
-        Key: fileKey,
-        Body: file.buffer,
-        ACL: acl,
-        ContentType: file.mimeType,
-      })
-
-      return data
+    let fileBufferOrStream: Buffer | stream.Readable
+    if (file.tempFilePath) {
+      fileBufferOrStream = fs.createReadStream(file.tempFilePath)
+    } else {
+      fileBufferOrStream = file.buffer
     }
 
-    console.log('Initiating multipart upload...', { fileKey })
-    const { UploadId: uploadId } = await getStorageClient().createMultipartUpload({
+    await getStorageClient().putObject({
       Bucket: bucket,
       Key: fileKey,
+      Body: fileBufferOrStream,
       ACL: acl,
       ContentType: file.mimeType,
     })
-
-    if (!uploadId) {
-      throw new Error('No upload ID returned from S3')
-    }
-
-    const partSize = 1024 * 1024 * 5 // 5MB
-    const parts = []
-
-    try {
-      const totalParts = file.buffer.length / partSize
-      for (let i = 0; i < file.buffer.length; i += partSize) {
-        const partNumber = i / partSize + 1
-        const part = Uint8Array.prototype.slice.call(file.buffer, i, i + partSize)
-
-        console.log('Uploading part...', {
-          fileKey,
-          partNumber,
-          totalParts,
-        })
-
-        const uploadPart = await getStorageClient().uploadPart({
-          Bucket: bucket,
-          Key: fileKey,
-          Body: part,
-          PartNumber: partNumber,
-          UploadId: uploadId,
-        })
-        parts.push({
-          ETag: uploadPart.ETag,
-          PartNumber: partNumber,
-        })
-      }
-
-      await getStorageClient().completeMultipartUpload({
-        Bucket: bucket,
-        Key: fileKey,
-        MultipartUpload: {
-          Parts: parts,
-        },
-        UploadId: uploadId,
-      })
-    } catch {
-      await getStorageClient().abortMultipartUpload({
-        Bucket: bucket,
-        Key: fileKey,
-        UploadId: uploadId,
-      })
-    }
 
     return data
   }

--- a/src/adapters/s3/index.ts
+++ b/src/adapters/s3/index.ts
@@ -1,4 +1,5 @@
 import * as AWS from '@aws-sdk/client-s3'
+import type { S3 } from '@aws-sdk/client-s3'
 import type { Adapter, GeneratedAdapter } from '../../types'
 import { getGenerateURL } from './generateURL'
 import { getHandler } from './staticHandler'
@@ -16,9 +17,10 @@ export const s3Adapter =
   ({ config, bucket, acl }: Args): Adapter =>
   ({ collection, prefix }): GeneratedAdapter => {
     let storageClient: AWS.S3 | null = null
-    const getStorageClient = () => {
+    const getStorageClient = (): S3 => {
       if (storageClient) return storageClient
-      return (storageClient = new AWS.S3(config))
+      storageClient = new AWS.S3(config)
+      return storageClient
     }
 
     return {

--- a/src/adapters/s3/index.ts
+++ b/src/adapters/s3/index.ts
@@ -1,5 +1,4 @@
 import * as AWS from '@aws-sdk/client-s3'
-import type { S3 } from '@aws-sdk/client-s3'
 import type { Adapter, GeneratedAdapter } from '../../types'
 import { getGenerateURL } from './generateURL'
 import { getHandler } from './staticHandler'
@@ -17,7 +16,7 @@ export const s3Adapter =
   ({ config, bucket, acl }: Args): Adapter =>
   ({ collection, prefix }): GeneratedAdapter => {
     let storageClient: AWS.S3 | null = null
-    const getStorageClient = (): S3 => {
+    const getStorageClient = () => {
       if (storageClient) return storageClient
       storageClient = new AWS.S3(config)
       return storageClient

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ import type { Configuration as WebpackConfig } from 'webpack'
 export interface File {
   buffer: Buffer
   filename: string
+  filesize: number
   mimeType: string
+  tempFilePath?: string
 }
 
 export type HandleUpload = (args: {

--- a/src/utilities/getIncomingFiles.ts
+++ b/src/utilities/getIncomingFiles.ts
@@ -18,6 +18,8 @@ export function getIncomingFiles({
       filename: data.filename,
       mimeType: data.mimeType,
       buffer: file.data,
+      tempFilePath: file.tempFilePath,
+      filesize: file.size,
     }
 
     files = [mainFile]
@@ -30,6 +32,7 @@ export function getIncomingFiles({
               filename: `${resizedFileData.filename}`,
               mimeType: data.mimeType,
               buffer: req.payloadUploadSizes[key],
+              filesize: req.payloadUploadSizes[key].length,
             },
           ])
         }


### PR DESCRIPTION
The S3 plugin was using the `putObject` function for all uploads. This is an issue for large files (>100MB).

This PR implements S3's multipart upload for large file sizes.