### PR TITLE
feat(azure): Add support for partial content requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "rimraf": "^4.1.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "range-parser": "^1.2.1"
   }
 }

--- a/src/adapters/azure/staticHandler.ts
+++ b/src/adapters/azure/staticHandler.ts
@@ -20,8 +20,6 @@ export const getHandler = ({ getStorageClient, collection }: Args): StaticHandle
 
       const { start, end } = await getRangeFromHeader(blockBlobClient, req.headers.range)
 
-      console.log({ start, end })
-
       const blob = await blockBlobClient.download(start, end)
       // eslint-disable-next-line no-underscore-dangle
       const response = blob._response

--- a/src/adapters/azure/staticHandler.ts
+++ b/src/adapters/azure/staticHandler.ts
@@ -1,8 +1,9 @@
-import path from 'path'
 import type { ContainerClient } from '@azure/storage-blob'
+import path from 'path'
 import type { CollectionConfig } from 'payload/types'
 import type { StaticHandler } from '../../types'
 import { getFilePrefix } from '../../utilities/getFilePrefix'
+import getRangeFromHeader from '../../utilities/getRangeFromHeader'
 
 interface Args {
   getStorageClient: () => ContainerClient
@@ -17,13 +18,15 @@ export const getHandler = ({ getStorageClient, collection }: Args): StaticHandle
         path.posix.join(prefix, req.params.filename),
       )
 
-      const blob = await blockBlobClient.download(0)
+      const { start, end } = await getRangeFromHeader(blockBlobClient, req.headers.range)
 
-      res.set({
-        'Content-Length': blob.contentLength,
-        'Content-Type': blob.contentType,
-        ETag: blob.etag,
-      })
+      console.log({ start, end })
+
+      const blob = await blockBlobClient.download(start, end)
+      // eslint-disable-next-line no-underscore-dangle
+      const response = blob._response
+      res.header(response.headers.rawHeaders())
+      res.status(response.status)
 
       if (blob?.readableStreamBody) {
         return blob.readableStreamBody.pipe(res)

--- a/src/utilities/getRangeFromHeader.ts
+++ b/src/utilities/getRangeFromHeader.ts
@@ -1,0 +1,27 @@
+import type { BlockBlobClient } from '@azure/storage-blob'
+import parseRange from 'range-parser'
+
+const getRangeFromHeader = async (
+  blockBlobClient: BlockBlobClient,
+  rangeHeader?: string,
+): Promise<{ start: number; end: number | undefined }> => {
+  const fullRange = { start: 0, end: undefined }
+
+  if (!rangeHeader) {
+    return fullRange
+  }
+
+  const size = await blockBlobClient.getProperties().then(props => props.contentLength)
+  if (size === undefined) {
+    return fullRange
+  }
+
+  const range = parseRange(size, rangeHeader)
+  if (range === -1 || range === -2 || range.type !== 'bytes' || range.length !== 1) {
+    return fullRange
+  }
+
+  return range[0]
+}
+
+export default getRangeFromHeader


### PR DESCRIPTION
- Added small dependencies to parse range headers properly
- Forward blob storage download response with headers instead of setting them manually.
- Added support for partial blob download.

Blob storage only accepts a small subset of all possible range headers, therefore I decided to ignore the header and return the full blob if the header is not fit for partial blob download in order not to break backward compatibility.

The proper handling of partial content allows html5 video/audio players to properly request the content they need while playing a video, e.g. seeking to a particular duration.