### PR TITLE
added default value for GCS_CREDENTIALS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ const adapter = gcsAdapter({
     // you can choose any method for authentication, and authorization which is being provided by `@google-cloud/storage`
     keyFilename: './gcs-credentials.json',
     //OR
-    credentials: JSON.parse(process.env.GCS_CREDENTIALS) // this env variable will have stringify version of your credentials.json file
+    credentials: JSON.parse(process.env.GCS_CREDENTIALS || "{}") // this env variable will have stringify version of your credentials.json file
   },
   bucket: process.env.GCS_BUCKET,
 })


### PR DESCRIPTION
without default value, it gives error in payload admin page (in console of browser)

caught SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at ./src/payload.config.ts 

as envs are not availabe in payload admin GCS_CREDENTIALS gives undefined resulting JSON.parse(undefined) raises this error