### PR TITLE
feat: add enabled property to conditionally enable/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ export default buildConfig({
 });
 ```
 
+### Conditionally Enabling/Disabling
+
+The proper way to conditionally enable/disable this plugin is to use the `enabled` property.
+
+```ts
+cloudStorage({
+  enabled: process.env.MY_CONDITION === 'true',
+  collections: {
+    'my-collection-slug': {
+      adapter: theAdapterToUse, // see docs for the adapter you want to use
+    },
+  },
+}),
+```
+
+If the code is included *in any way in your config* but conditionally disabled in another fashion, you may run into issues such as `Webpack Build Error: Can't Resolve 'fs' and 'stream'` or similar because the plugin must be run at all times in order to properly extend the webpack config.
+
 ## Features
 
 **Adapter-based Implementation**

--- a/dev/src/payload.config.ts
+++ b/dev/src/payload.config.ts
@@ -83,7 +83,7 @@ export default buildConfig({
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },
   plugins: [
-    // @ts-expect-error
+    // @ts-expect-error Conflicting types for relative package
     cloudStorage({
       collections: {
         media: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -16,19 +16,26 @@ import { getFields } from './fields/getFields'
 
 export const cloudStorage =
   (pluginOptions: PluginOptions) =>
-  (config: Config): Config => {
-    const { collections: allCollectionOptions } = pluginOptions
+  (incomingConfig: Config): Config => {
+    const { collections: allCollectionOptions, enabled } = pluginOptions
+    const config = { ...incomingConfig }
 
-    const webpack = extendWebpackConfig({ options: pluginOptions, config })
+    const webpack = extendWebpackConfig({ options: pluginOptions, config: incomingConfig })
+
+    config.admin = {
+      ...(config.admin || {}),
+      webpack,
+    }
+
+    // Return early if disabled. Only webpack config mods are applied.
+    if (enabled === false) {
+      return config
+    }
 
     const initFunctions: Array<() => void> = []
 
     return {
       ...config,
-      admin: {
-        ...(config.admin || {}),
-        webpack,
-      },
       collections: (config.collections || []).map(existingCollection => {
         const options = allCollectionOptions[existingCollection.slug]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,5 +69,11 @@ export interface CollectionOptions {
 }
 
 export interface PluginOptions {
+  /**
+   * Whether or not to enable the plugin
+   *
+   * Default: true
+   */
+  enabled?: boolean
   collections: Record<string, CollectionOptions>
 }


### PR DESCRIPTION
Resolves conditionally enabling/disabling of the plugin. Adds `enabled` property to the plugin which allows the plugin to safely enable/disable itself. 

Previously, if the code is included _at all_ in the config it would be included in the bundle. This was an issue if the plugin needed webpack aliases because the payload config's webpack config would not get extended with the aliases. this provides a proper way to do this.

Usage:

```ts
cloudStorage({
  enabled: process.env.MY_CONDITION === 'true',
  collections: {
    media: {
      adapter,
    },
  },
}),
```


Fixes #54 
Fixes #55 