### PR TITLE
Add support for 'prefix' field on individual uploads, takes priority over global prefix field

### DIFF
--- a/src/adapters/azure/handleUpload.ts
+++ b/src/adapters/azure/handleUpload.ts
@@ -15,8 +15,10 @@ interface Args {
 const multipartThreshold = 1024 * 1024 * 50 // 50MB
 export const getHandleUpload = ({ getStorageClient, prefix = '' }: Args): HandleUpload => {
   return async ({ data, file }) => {
+    const fileKey = path.posix.join(data.prefix || prefix, file.filename)
+    
     const blockBlobClient = getStorageClient().getBlockBlobClient(
-      path.posix.join(prefix, file.filename),
+      fileKey,
     )
 
     // when there are no temp files, or the upload is less than the threshold size, do not stream files

--- a/src/adapters/gcs/handleUpload.ts
+++ b/src/adapters/gcs/handleUpload.ts
@@ -18,7 +18,9 @@ export const getHandleUpload = ({
   prefix = '',
 }: Args): HandleUpload => {
   return async ({ data, file }) => {
-    const gcsFile = getStorageClient().bucket(bucket).file(path.posix.join(prefix, file.filename))
+    const fileKey = path.posix.join(data.prefix || prefix, file.filename)
+
+    const gcsFile = getStorageClient().bucket(bucket).file(fileKey)
     await gcsFile.save(file.buffer, {
       metadata: {
         contentType: file.mimeType,

--- a/src/adapters/s3/handleUpload.ts
+++ b/src/adapters/s3/handleUpload.ts
@@ -24,7 +24,7 @@ export const getHandleUpload = ({
   prefix = '',
 }: Args): HandleUpload => {
   return async ({ data, file }) => {
-    const fileKey = path.posix.join(prefix, file.filename)
+    const fileKey = path.posix.join(data.prefix || prefix, file.filename)
 
     const fileBufferOrStream: Buffer | stream.Readable = file.tempFilePath
       ? fs.createReadStream(file.tempFilePath)

--- a/src/fields/getFields.ts
+++ b/src/fields/getFields.ts
@@ -129,7 +129,7 @@ export const getFields = ({
   }
 
   // If prefix is enabled, save it to db
-  if (prefix) {
+  if (prefix != undefined) {
     let existingPrefixFieldIndex = -1
 
     const existingPrefixField = fields.find((existingField, i) => {


### PR DESCRIPTION
The purpose of this PR is to allow for setting a 'prefix' field on a per-upload basis when creating a new upload instead of only being able to set prefixes in the plugin config. The prefix field can either be entered manually using a field input, or set in a beforeChange or beforeOperation hook.

If using a hook, the field 'prefix' will need to either be added to the collection manually, or you can set the plugin config 'prefix' value in order to make sure the field is added to the collection. I have added support in this PR for the plugin config 'prefix' value to be an empty string.

The use case for this in my company's project is to be able to set a prefix based on the current tenant/website. It worked well for that case when testing this plugin change locally.

Let me know if there or any issues with this implementation I should fix, or if you'd rather not include it at all and I can keep it on my own branch. Thanks!