### PR TITLE
fix: Use mime type from the resized file data.

### DIFF
--- a/src/utilities/getIncomingFiles.ts
+++ b/src/utilities/getIncomingFiles.ts
@@ -30,7 +30,7 @@ export function getIncomingFiles({
           files = files.concat([
             {
               filename: `${resizedFileData.filename}`,
-              mimeType: data.mimeType,
+              mimeType: resizedFileData.mimeType,
               buffer: req.payloadUploadSizes[key],
               filesize: req.payloadUploadSizes[key].length,
             },


### PR DESCRIPTION
The incoming [req.payloadUploadSizes](https://github.com/payloadcms/plugin-cloud-storage/blob/3d5858ca6d45d73c22e9bb97c2b443758d93400b/src/utilities/getIncomingFiles.ts#L29C13-L29C26) can have resized files that have a different mime type than the uploaded main/original file. 

Payload's upload collection supports passing additional options to the sharp lib. For example, you could [pass a custom](https://github.com/payloadcms/payload/blob/8fc953605a4e15010e23b0086b1e958f7c083ccf/src/uploads/imageResizer.ts#L180) [formatOptions](https://payloadcms.com/docs/upload/overview#enabling-uploads) to the sharp lib which could produce a different file output format/mime-type.  

I've changed the mime type to that of the resized image's mime type instead of defaulting to the original mime type. So that the uploaded resized files also have the correct mime types.